### PR TITLE
Added composer meta-data file, for use with composer/packagist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 .settings/
 PHPUnit/
 report/
+/vendor/

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,14 @@
+{
+    "name": "antonterekhov/orientdb-php",
+    "description": "A plain PHP driver to OrientDB graph database using its binary protocol.",
+    "license": "BSD-3-Clause",
+    "authors": [
+        {
+            "name": "Anton Terekhov",
+            "email": "anton.a.terekhov@gmail.com"
+        }
+    ],
+    "require": {
+
+    }
+}


### PR DESCRIPTION
This change adds a composer.json file, so that the package can be listed at https://packagist.org/

If you're not familiar with Composer/Packagist, it's a PHP package management tool that is gaining a lot of popularity projects such as Symfony, Drupal, and SilverStripe (which I'm involved in).  It differs from PEAR in that the packages are downloaded per-project, rather than being installed in a system location.

The attached composer.json file, if you merged it in and then submitted the repository at https://packagist.org/, would mean that anyone using composer can add this to their project by running 'composer require antonterekhov/orientdb-php', after which the code would be available at ./vendor/antonterekhov/orientdb-php.

I wasn't sure if the package name should be something different, e.g. netmonsters/orientdb-php.  I'm happy to change the pull request if needs be, or of course, you could edit it yourself. :-) 

More information is available at http://getcomposer.org/
